### PR TITLE
fix: 将组件中button标签换成其他标签实现，避免button触发 form 提交

### DIFF
--- a/packages/action-sheet/src/main.vue
+++ b/packages/action-sheet/src/main.vue
@@ -15,7 +15,7 @@
       <i class="wd-action-sheet__close wd-icon-add" @click="close"></i>
     </div>
     <div v-if="actions && actions.length" class="wd-action-sheet__actions">
-      <button
+      <div
         v-for="(item, index) in actions"
         :key="index"
         :class="{
@@ -30,7 +30,7 @@
           <span class="wd-action-sheet__name">{{ item.name }}</span>
           <span v-if="item.subname" class="wd-action-sheet__subname">{{ item.subname }}</span>
         </template>
-      </button>
+      </div>
     </div>
     <template v-if="formatPanels && formatPanels.length">
       <div
@@ -52,7 +52,7 @@
       </div>
     </template>
     <slot></slot>
-    <button v-if="cancelText" class="wd-action-sheet__cancel" @click="handleCancel">{{ cancelText }}</button>
+    <div v-if="cancelText" class="wd-action-sheet__cancel" @click="handleCancel">{{ cancelText }}</div>
   </wd-popup>
 </template>
 

--- a/packages/tabs/src/main.vue
+++ b/packages/tabs/src/main.vue
@@ -183,7 +183,7 @@ export default {
         let key = item.name || index
         return (
           <div key={key} class='wd-tabs__map-nav-item'>
-            <button
+            <span
               key={key}
               class={{
                 'wd-tabs__map-nav-btn': true,
@@ -195,7 +195,7 @@ export default {
                 !item.disabled && this.toggleMap()
               }}>
               {title}
-            </button>
+            </span>
           </div>
         )
       })

--- a/src/mixins/picker.js
+++ b/src/mixins/picker.js
@@ -68,21 +68,21 @@ export default {
       render (h) {
         const { onCancel, onConfirm, cancelButtonText, confirmButtonText, title, loading, t } = this.target
         const cancelButton = (
-          <button
+          <span
             class="wd-picker__action wd-picker__action--cancel"
             onClick={onCancel}
           >
             {cancelButtonText || t('wd.picker.cancel')}
-          </button>
+          </span>
         )
 
         const confirmButton = (
-          <button
+          <span
             onClick={loading ? () => { } : onConfirm}
             class={['wd-picker__action', loading ? 'is-loading' : '']}
           >
             {confirmButtonText || t('wd.picker.done')}
-          </button>
+          </span>
         )
 
         const titleBlock = title ? <span class="wd-picker__title">{title}</span> : ''


### PR DESCRIPTION
#### Bug 修复

- ActionSheet
  - 将 button 标签替换为 div，避免触发 form 标签的提交操作 @yawuling 
- Picker
  - 将 button 标签替换为 span，避免触发 form 标签的提交操作 @yawuling 
- Tabs
  - 将 button 标签替换为 span，避免触发 form 标签的提交操作 @yawuling 