### PR TITLE
fix: radio 、checkbox 添加 line-height，避免被外部影响位置

### DIFF
--- a/src/style/checkbox.scss
+++ b/src/style/checkbox.scss
@@ -18,6 +18,7 @@
     width: $-checkbox-size;
     height: $-checkbox-size;
     border: 2px solid $-checkbox-border-color;
+    line-height: 1.1;
     border-radius: 50%;
     color: $-checkbox-check-color;
     background: $-checkbox-bg;

--- a/src/style/radio.scss
+++ b/src/style/radio.scss
@@ -21,6 +21,7 @@
     width: $-radio-size;
     height: $-radio-size;
     font-size: $-radio-size;
+    line-height: 1.1;
     color: transparent;
     display: none;
     background: $-radio-bg;


### PR DESCRIPTION
#### Bug 修复

- Checkbox
  - 添加行高，避免选中状态时因为外部行高影响导致错位 @yawuling 
- Radio
  - 添加行高，避免选中状态时因为外部行高影响导致错位 @yawuling 