### PR TITLE
style: popover 样式切换修复

### DIFF
--- a/examples/docs/docs/changelog.md
+++ b/examples/docs/docs/changelog.md
@@ -12,6 +12,8 @@
   - 修复直接使用 messageBox(options) 时 type 类型没有设置初始配置的问题 (by [@yawuling](https://github.com/yawuling) ) )
 - PickerView
   - 修复value为null时，无法自动设置value为第一项的问题 (by [@yawuling](https://github.com/yawuling) ) )
+- Popover
+  - 修复属性 placement 为 top/right 系列位置时，arrow样式位置失效问题  (by [@HXCStudio123](https://github.com/HXCStudio123) )
 - Search
   - 修复样式超出右侧边界问题 (by [@yawuling](https://github.com/yawuling) ) )
 

--- a/src/style/abstracts/_mixin.scss
+++ b/src/style/abstracts/_mixin.scss
@@ -217,6 +217,7 @@
 
   @include e(arrow-down) {
     transform: translateX(-50%);
+    bottom: -6px;
     &:after {
       content: "";
       width: $size;
@@ -256,6 +257,7 @@
   }
   @include e(arrow-right) {
     transform: translateY(-50%);
+    right: 0;
     &:after {
       content: "";
       width: $size;


### PR DESCRIPTION
- Popover
  - 修复属性 placement 为 top/right 系列位置时，arrow样式位置失效问题  (by @HXCStudio123  )