### PR TITLE
fix(messageBox): 修复部分属性未重置的问题

### DIFF
--- a/examples/docs/docs/changelog.md
+++ b/examples/docs/docs/changelog.md
@@ -13,6 +13,9 @@
   - 新增 `onClose` 关闭回调属性 (by [@yawuling](https://github.com/yawuling) )
 #### Bug 修复
 
+- MessageBox
+  - 修复 `confirmButtonText`、`cancelButtonText`、`lockScroll` 属性未重置的问题 (by [@yawuling](https://github.com/yawuling) )
+  - 修复 `teleport` 属性的文档位置，该属性只能对组件调用方式有效 (by [@yawuling](https://github.com/yawuling) )
 - SelectPicker
   - 修复 `type` 为 'radio'，搜索时未正确高亮搜索文本的问题 (by [@yawuling](https://github.com/yawuling) )
 

--- a/examples/docs/docs/messageBox.md
+++ b/examples/docs/docs/messageBox.md
@@ -175,7 +175,6 @@ this.$messageBox.prompt(title, options) //  title 可以跳过不写，即支持
 | inputValidate | 当type为prompt时，输入框校验函数，点击确定按钮时进行校验 | function | - | - | - |
 | confirmButtonText | 确定按钮文案 | string | - | 确定 | - |
 | cancelButtonText | 取消按钮文案 | string | - | 取消 | - |
-| teleport | 指定挂载的 HTML 节点, 可以为字符串，也可以为对象，为对象时有 `to` 和 `disabled` 属性，`to` 表示挂载点，`disabled` 表示挂载到当前节点上 | string / object  | - | body | - |
 
 ### MessageBox 组件调用
 
@@ -190,6 +189,7 @@ this.$messageBox.prompt(title, options) //  title 可以跳过不写，即支持
 | close-on-popstate | 页面返回时自动关闭 | boolean | - | true | - |
 | confirm-button-text | 确定按钮文案 | string | - | 确定 | - |
 | cancel-button-text | 取消按钮文案 | string | - | 取消 | - |
+| teleport | 指定挂载的 HTML 节点, 可以为字符串，也可以为对象，为对象时有 `to` 和 `disabled` 属性，`to` 表示挂载点，`disabled` 表示挂载到当前节点上 | string / object  | - | body | - |
 
 #### Events
 

--- a/packages/message-box/index.js
+++ b/packages/message-box/index.js
@@ -21,7 +21,10 @@ let defaults = {
   inputValidate: '', // prompt中验证input数据的函数
   showConfirmButton: true,
   showCancelButton: false,
-  inputError: ''
+  confirmButtonText: '',
+  cancelButtonText: '',
+  inputError: '',
+  lockScroll: true
 }
 
 const merge = (target, ...args) => {


### PR DESCRIPTION
#### Bug 修复

- MessageBox
  - 修复 `confirmButtonText`、`cancelButtonText`、`lockScroll` 属性未重置的问题
  - 修复 `teleport` 属性的文档位置，该属性只能对组件调用方式有效